### PR TITLE
Category CRUD API 구현 및 관련 함수 수정

### DIFF
--- a/src/components/Sidebar/ArticlePreviewList.tsx
+++ b/src/components/Sidebar/ArticlePreviewList.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
-import { RootState } from '@lib/store';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch, RootState } from '@lib/store';
 import { articleType } from '@components/Article/ArticleType';
 import { articleList } from '@components/Article/Article.mock';
 import styles from '@components/Sidebar/ArticlePreviewList.module.css';
 import CategoryItem from '@components/Sidebar/ArticlePreviewCategoryItem';
 import PreviewArticleItem from '@components/Sidebar/ArticlePreviewItem';
-import { CategoryType } from '@lib/features/category/categorySlice';
+import {
+	CategoryType,
+} from '@lib/features/category/categorySlice';
+import { getCategories } from '@/lib/features/category/categoryThunk';
 
 interface classifyPostType {
 	tabName: '분류';
@@ -21,6 +24,7 @@ interface previewArticleType {
 type sidebarListType = classifyPostType | previewArticleType;
 
 const ArticlePreviewList = ({ currentTab }: { currentTab: string }) => {
+	const dispatch = useDispatch<AppDispatch>();
 	const categoryList = useSelector(
 		(state: RootState) => state.category.categoryList,
 	);
@@ -28,6 +32,11 @@ const ArticlePreviewList = ({ currentTab }: { currentTab: string }) => {
 		tabName: '분류',
 		articleList: [],
 	});
+
+	useEffect(() => {
+		dispatch(getCategories());
+	}, []);
+
 	useEffect(() => {
 		if (currentTab === 'classifyPost') {
 			setPreviewArticle({
@@ -45,7 +54,7 @@ const ArticlePreviewList = ({ currentTab }: { currentTab: string }) => {
 				articleList: articleList.slice(-3),
 			});
 		}
-	}, [currentTab]);
+	}, [currentTab, categoryList]);
 
 	return (
 		<section className={styles.classify}>

--- a/src/lib/features/category/category.test.tsx
+++ b/src/lib/features/category/category.test.tsx
@@ -1,5 +1,5 @@
 import categoryReducer, {
-	setCategory,
+	addCategory,
 	selectCategory,
 	CategoryType,
 	CategoryStateType,
@@ -12,13 +12,13 @@ const initialState: CategoryStateType = {
 	error: null,
 };
 
-const testSetCategory = (params: CategoryType, state = initialState) => {
-	const action = setCategory(params);
+const testAddCategory = (params: CategoryType, state = initialState) => {
+	const action = addCategory(params);
 	return categoryReducer(state, action);
 };
 
 test('카테고리 항목 추가', () => {
-	const newState = testSetCategory({ id: 'technology', name: '기술' });
+	const newState = testAddCategory({ id: 'technology', name: '기술' });
 	expect(newState.categoryList.at(-1)).toEqual({
 		id: 'technology',
 		name: '기술',
@@ -26,10 +26,10 @@ test('카테고리 항목 추가', () => {
 });
 
 test('카테고리 항목 여러개 추가', () => {
-	const state1 = testSetCategory({ id: 'all', name: '전체' });
-	const state2 = testSetCategory({ id: 'project', name: 'project' }, state1);
-	const state3 = testSetCategory({ id: 'study', name: 'study' }, state2);
-	const newState = testSetCategory({ id: 'technology', name: '기술' }, state3);
+	const state1 = testAddCategory({ id: 'all', name: '전체' });
+	const state2 = testAddCategory({ id: 'project', name: 'project' }, state1);
+	const state3 = testAddCategory({ id: 'study', name: 'study' }, state2);
+	const newState = testAddCategory({ id: 'technology', name: '기술' }, state3);
 	expect(newState.categoryList).toEqual([
 		{ id: 'all', name: '전체' },
 		{ id: 'project', name: 'project' },
@@ -39,7 +39,7 @@ test('카테고리 항목 여러개 추가', () => {
 });
 
 test('특정 카테고리 선택', () => {
-	const addedState = testSetCategory({ id: 'technology', name: '기술' });
+	const addedState = testAddCategory({ id: 'technology', name: '기술' });
 	const action = selectCategory('technology');
 	const newState = categoryReducer(addedState, action);
 	expect(newState.selectedCategory).toBe('technology');

--- a/src/lib/features/category/category.test.tsx
+++ b/src/lib/features/category/category.test.tsx
@@ -1,6 +1,7 @@
 import categoryReducer, {
 	addCategory,
 	selectCategory,
+	removeSelectedCategory,
 	CategoryType,
 	CategoryStateType,
 } from '@lib/features/category/categorySlice';
@@ -43,4 +44,14 @@ test('특정 카테고리 선택', () => {
 	const action = selectCategory('technology');
 	const newState = categoryReducer(addedState, action);
 	expect(newState.selectedCategory).toBe('technology');
+});
+
+test('선택된 카테고리 삭제', () => {
+	const addedState = testAddCategory({ id: 'technology', name: '기술' });
+	const action = selectCategory('technology');
+	const newState = categoryReducer(addedState, action);
+	const newAction = removeSelectedCategory();
+	const removeState = categoryReducer(newState, newAction);
+	expect(removeState.categoryList).toEqual([]);
+	expect(removeState.selectedCategory).toBe(null);
 });

--- a/src/lib/features/category/category.test.tsx
+++ b/src/lib/features/category/category.test.tsx
@@ -8,7 +8,8 @@ import categoryReducer, {
 const initialState: CategoryStateType = {
 	categoryList: [],
 	selectedCategory: null,
-	currentArticleList: null,
+	loading: false,
+	error: null,
 };
 
 const testSetCategory = (params: CategoryType, state = initialState) => {

--- a/src/lib/features/category/categorySlice.ts
+++ b/src/lib/features/category/categorySlice.ts
@@ -23,7 +23,11 @@ const categorySlice = createSlice({
 	name: 'category',
 	initialState,
 	reducers: {
-		setCategory: (state, action: PayloadAction<CategoryType>) => {
+		addCategory: (state, action: PayloadAction<CategoryType>) => {
+			const exists = state.categoryList.some(
+				({ id }) => id === action.payload.id,
+			);
+			if (exists) return;
 			state.categoryList.push({
 				id: action.payload.id,
 				name: action.payload.name,
@@ -35,5 +39,5 @@ const categorySlice = createSlice({
 	},
 });
 
-export const { setCategory, selectCategory } = categorySlice.actions;
+export const { addCategory, selectCategory } = categorySlice.actions;
 export default categorySlice.reducer;

--- a/src/lib/features/category/categorySlice.ts
+++ b/src/lib/features/category/categorySlice.ts
@@ -66,5 +66,6 @@ const categorySlice = createSlice({
 	},
 });
 
-export const { addCategory, selectCategory } = categorySlice.actions;
+export const { addCategory, selectCategory, removeSelectedCategory } =
+	categorySlice.actions;
 export default categorySlice.reducer;

--- a/src/lib/features/category/categorySlice.ts
+++ b/src/lib/features/category/categorySlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { getCategories } from '@lib/features/category/categoryThunk';
 
 export interface CategoryType {
 	id: string;
@@ -42,6 +43,26 @@ const categorySlice = createSlice({
 			);
 			state.selectedCategory = null;
 		},
+	},
+	extraReducers: builder => {
+		builder
+			.addCase(getCategories.pending, state => {
+				state.loading = true;
+				state.error = null;
+			})
+			.addCase(
+				getCategories.fulfilled,
+				(state, action: PayloadAction<CategoryType[]>) => {
+					state.loading = false;
+					state.error = null;
+					state.categoryList = action.payload;
+				},
+			)
+			.addCase(getCategories.rejected, (state, action) => {
+				state.loading = false;
+				state.error =
+					action.error.message || '카테고리를 불러오는데 실패했습니다.';
+			});
 	},
 });
 

--- a/src/lib/features/category/categorySlice.ts
+++ b/src/lib/features/category/categorySlice.ts
@@ -36,6 +36,12 @@ const categorySlice = createSlice({
 		selectCategory: (state, action: PayloadAction<string | null>) => {
 			state.selectedCategory = action.payload;
 		},
+		removeSelectedCategory: state => {
+			state.categoryList = state.categoryList.filter(
+				({ id }) => id !== state.selectedCategory,
+			);
+			state.selectedCategory = null;
+		},
 	},
 });
 

--- a/src/lib/features/category/categorySlice.ts
+++ b/src/lib/features/category/categorySlice.ts
@@ -8,15 +8,15 @@ export interface CategoryType {
 export interface CategoryStateType {
 	categoryList: CategoryType[];
 	selectedCategory: string | null;
+	loading: boolean;
+	error: string | null;
 }
 
 const initialState: CategoryStateType = {
-	categoryList: [
-		{ id: 'all', name: '전체' },
-		{ id: 'project', name: 'project' },
-		{ id: 'study', name: 'study' },
-	],
+	categoryList: [],
 	selectedCategory: null,
+	loading: false,
+	error: null,
 };
 
 const categorySlice = createSlice({
@@ -29,7 +29,7 @@ const categorySlice = createSlice({
 				name: action.payload.name,
 			});
 		},
-		selectCategory: (state, action: PayloadAction<string>) => {
+		selectCategory: (state, action: PayloadAction<string | null>) => {
 			state.selectedCategory = action.payload;
 		},
 	},

--- a/src/lib/features/category/categoryThunk.ts
+++ b/src/lib/features/category/categoryThunk.ts
@@ -1,0 +1,39 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { api } from '@/utils/api';
+
+// Action Type Prefix: [slice]/[action][target]
+// 카테고리 목록 조회
+export const getCategories = createAsyncThunk('category/getList', async () => {
+	const response = await api.get('/api/category');
+	return response;
+});
+
+// 카테고리 조회
+export const getCategory = createAsyncThunk('category/getItem', async id => {
+	const response = await api.get(`/api/category/${id}`);
+	return response;
+});
+
+// 카테고리 추가
+export const setCategory = createAsyncThunk('category/setItem', async data => {
+	const response = await api.post('/api/category', data);
+	return response;
+});
+
+// 카테고리 수정
+export const updateCategory = createAsyncThunk(
+	'category/updateItem',
+	async (id, data) => {
+		const response = await api.put(`/api/category/${id}`, data);
+		return response;
+	},
+);
+
+// 카테고리 삭제
+export const deleteCategory = createAsyncThunk(
+	'category/deleteItem',
+	async id => {
+		const response = await api.delete(`/api/category/${id}`);
+		return response;
+	},
+);


### PR DESCRIPTION
- Category CRUD API 구현
  - CRUD thunk 추가
  - Category 변수(loding, error) 추가
  - Category 다른 함수명 수정(setCategory -> addCategory)
<br />

- Category 삭제 함수 구현
  - reducer 내 선택된 Category 삭제 함수 구현(API 미연동)
  - 테스트 함수 작성
<br />

- Category 목록 조회 API 연동
  - thunk로 구현한 Category 목록 조회 API 호출 및 렌더링